### PR TITLE
fix: only assign property if we have a proper descriptor

### DIFF
--- a/lib/dot/object.jst
+++ b/lib/dot/object.jst
@@ -311,7 +311,7 @@ function deepExtend({{# def.arg }} obj, onlyEnumerable, preserveStructure) {
         _extendTree(selfNode[key], value, onlyEnumerable, preserveStructure, objTraversed);
     } else {
         var descriptor = Object.getOwnPropertyDescriptor(objNode, key);
-        Object.defineProperty(selfNode, key, descriptor);
+        if (descriptor) Object.defineProperty(selfNode, key, descriptor);
     }
 #}}
 

--- a/lib/dot/object.jst
+++ b/lib/dot/object.jst
@@ -85,7 +85,8 @@ var constants = module.exports._constants = {
  * @return {Object}
  */
 {{## def.getDescriptor:_obj:
-    descriptors[key] = Object.getOwnPropertyDescriptor(_obj, key);
+    var desc = Object.getOwnPropertyDescriptor(_obj, key);
+    if (desc) descriptors[key] = desc;
 #}}
 
 function extend({{# def.arg }} obj, onlyEnumerable) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protojs",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "ES5 object manipulation library for node and modern browsers",
   "main": "lib/proto.js",
   "files": [

--- a/test/proto_object_test.js
+++ b/test/proto_object_test.js
@@ -253,29 +253,47 @@ describe('Object functions', function() {
     });
 
 
-    it('deepExtend object shouldn\'t throw when encountering non-enumerable properties on extending object', function () {
+    function testExtendWithNonEnum(method) {
         function Test() {}
         Test.prototype.foo = 'bar';
 
         const obj = { bar: 'foo' };
         const test = new Test;
         test.foobar = 'barfoo'; // own properties should get through
-        _.deepExtend(obj, test, true);
+        _[method](obj, test, true);
 
         assert.deepEqual(obj, { bar: 'foo', foobar: 'barfoo' });
+    }
+
+    it('deepExtend object shouldn\'t throw when encountering non-enumerable properties on extending object', function () {
+        testExtendWithNonEnum('deepExtend');
     });
 
 
-    it('deepExtend array shouldn\'t throw when encountering non-enumerable properties on extending array item', function () {
+    it('extend object shouldn\'t throw when encountering non-enumerable properties on extending object', function () {
+        testExtendWithNonEnum('extend');
+    });
+
+
+    function textExtendWithNonEnumArray(method) {
         function Test() {}
         Test.prototype.foo = 'bar';
 
         const arr = ['foo'];
         const test = new Test;
         test.foobar = 'barfoo'; // own properties should get through
-        _.deepExtend(arr, [test], true);
+        _[method](arr, [test], true);
 
         assert.deepEqual(arr, [{ foobar: 'barfoo' }]);
+    }
+
+    it('deepExtend array shouldn\'t throw when encountering non-enumerable properties on extending array item', function () {
+        textExtendWithNonEnumArray('deepExtend');
+    });
+
+
+    it('extend array shouldn\'t throw when encountering non-enumerable properties on extending array item', function () {
+        textExtendWithNonEnumArray('extend');
     });
 
 

--- a/test/proto_object_test.js
+++ b/test/proto_object_test.js
@@ -253,6 +253,32 @@ describe('Object functions', function() {
     });
 
 
+    it('deepExtend object shouldn\'t throw when encountering non-enumerable properties on extending object', function () {
+        function Test() {}
+        Test.prototype.foo = 'bar';
+
+        const obj = { bar: 'foo' };
+        const test = new Test;
+        test.foobar = 'barfoo'; // own properties should get through
+        _.deepExtend(obj, test, true);
+
+        assert.deepEqual(obj, { bar: 'foo', foobar: 'barfoo' });
+    });
+
+
+    it('deepExtend array shouldn\'t throw when encountering non-enumerable properties on extending array item', function () {
+        function Test() {}
+        Test.prototype.foo = 'bar';
+
+        const arr = ['foo'];
+        const test = new Test;
+        test.foobar = 'barfoo'; // own properties should get through
+        _.deepExtend(arr, [test], true);
+
+        assert.deepEqual(arr, [{ foobar: 'barfoo' }]);
+    });
+
+
     it('should define deepClone function', function() {
         var cloned = _.deepClone({ a: 1, b: { c: 2, d: { e: 3 } } });
         assert.deepEqual(cloned, { a: 1, b: { c: 2, d: { e: 3 } } });

--- a/test/proto_object_test.js
+++ b/test/proto_object_test.js
@@ -257,8 +257,8 @@ describe('Object functions', function() {
         function Test() {}
         Test.prototype.foo = 'bar';
 
-        const obj = { bar: 'foo' };
-        const test = new Test;
+        var obj = { bar: 'foo' };
+        var test = new Test;
         test.foobar = 'barfoo'; // own properties should get through
         _[method](obj, test, true);
 
@@ -279,8 +279,8 @@ describe('Object functions', function() {
         function Test() {}
         Test.prototype.foo = 'bar';
 
-        const arr = ['foo'];
-        const test = new Test;
+        var arr = ['foo'];
+        var test = new Test;
         test.foobar = 'barfoo'; // own properties should get through
         _[method](arr, [test], true);
 


### PR DESCRIPTION
Need to add a test for this, just as soon as I figure out exactly what is causing it. I believe the problem relates to attempt to extend a non-own property.